### PR TITLE
[Docs] Add autonomous agent blueprint and sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ For a detailed overview of the new architecture, technology stack, and implement
 ## Documentation
 
 Full documentation lives in the [docs](docs/README.md) directory. The legacy application can be installed by following the original [Getting Started](docs/user_guide/getting_started.md) guide. Documentation for v2 will be updated as development progresses.
+See [Autonomous Agent Playground](docs/design_documents/active_proposals/autonomous_agent_playground.md) for the new AutoGen framework blueprint.
 
 ## Contributing
 

--- a/agent_playground/README.md
+++ b/agent_playground/README.md
@@ -1,0 +1,26 @@
+# Agent Playground
+
+This directory provides a minimal sandbox for experimenting with autonomous agents.
+
+## Usage
+
+```python
+from trade_suite.data.data_source import Data
+from sentinel.alert_bot.manager import AlertDataManager
+from agent_playground.agents import MonitorAgent, ScraperAgent
+from agent_playground.sandbox import run_playground
+
+# Instantiate TradeSuite components
+
+data = Data()
+alert_manager = AlertDataManager(data)
+
+agents = [
+    MonitorAgent("monitor", data),
+    ScraperAgent("scraper", alert_manager),
+]
+
+run_playground(agents)
+```
+
+This is a starting point for building more complex AutoGen-style agents that leverage existing TradeSuite modules.

--- a/agent_playground/__init__.py
+++ b/agent_playground/__init__.py
@@ -1,0 +1,3 @@
+"""Autonomous agent playground package."""
+
+__all__ = ["base", "agents", "sandbox"]

--- a/agent_playground/agents.py
+++ b/agent_playground/agents.py
@@ -1,0 +1,47 @@
+"""Example autonomous agent implementations."""
+
+import asyncio
+from typing import Any
+
+from trade_suite.data.data_source import Data
+from sentinel.alert_bot.manager import AlertDataManager
+
+from .base import Agent
+
+
+class MonitorAgent(Agent):
+    """Agent that monitors real-time market data."""
+
+    def __init__(self, name: str, data: Data) -> None:
+        super().__init__(name)
+        self.data = data
+
+    async def run(self) -> None:
+        while True:
+            trades = await self.data.get_trades("coinbase", "BTC/USD", limit=10)
+            self.memory["last_trades"] = trades
+            await asyncio.sleep(5)
+
+
+class ScraperAgent(Agent):
+    """Agent that monitors SEC filings via Sentinel."""
+
+    def __init__(self, name: str, alert_manager: AlertDataManager) -> None:
+        super().__init__(name)
+        self.alert_manager = alert_manager
+
+    async def run(self) -> None:
+        while True:
+            await self.alert_manager.poll()
+            await asyncio.sleep(10)
+
+
+class SynthesisAgent(Agent):
+    """Agent that synthesizes reports using CopeNet tools."""
+
+    def __init__(self, name: str) -> None:
+        super().__init__(name)
+
+    async def run(self) -> None:
+        await asyncio.sleep(1)
+        # Placeholder for LLM-based report generation

--- a/agent_playground/base.py
+++ b/agent_playground/base.py
@@ -1,0 +1,17 @@
+"""Base classes for autonomous agents."""
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict
+
+
+class Agent(ABC):
+    """Abstract base class for all agents."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.memory: Dict[str, Any] = {}
+
+    @abstractmethod
+    async def run(self) -> None:
+        """Entry point for the agent's main loop."""
+        raise NotImplementedError

--- a/agent_playground/sandbox.py
+++ b/agent_playground/sandbox.py
@@ -1,0 +1,22 @@
+"""Simple sandbox runner for autonomous agents."""
+
+import asyncio
+from typing import Sequence
+
+from .base import Agent
+
+
+class Sandbox:
+    """Container for running agents concurrently."""
+
+    def __init__(self, agents: Sequence[Agent]):
+        self.agents = list(agents)
+
+    async def run(self) -> None:
+        await asyncio.gather(*(agent.run() for agent in self.agents))
+
+
+def run_playground(agents: Sequence[Agent]) -> None:
+    """Helper to start the sandbox."""
+    sandbox = Sandbox(agents)
+    asyncio.run(sandbox.run())

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ Welcome to the TradeSuite documentation hub. This directory provides guidance fo
 - [User Guide](user_guide/getting_started.md)
 - [Developer Guide](developer_guide/architecture.md)
 - [Design Documents](design_documents/)
+- [Autonomous Agent Playground](design_documents/active_proposals/autonomous_agent_playground.md)
 - [Code Reviews](code_reviews/)
 - [Changelogs](changelogs/main_changelog.md)
 

--- a/docs/design_documents/active_proposals/autonomous_agent_playground.md
+++ b/docs/design_documents/active_proposals/autonomous_agent_playground.md
@@ -1,0 +1,53 @@
+# Autonomous Agent Playground Design
+
+This proposal outlines a lightweight framework for creating AutoGen-style agents inside TradeSuite. The playground reuses existing modules to let agents plan tasks, gather data and generate reports.
+
+## 1. Architecture
+
+```
+Agents -> Sandbox -> TradeSuite Services (Data, AlertBot, Sentinel) -> Storage
+```
+
+- **Agents** encapsulate behaviour such as monitoring prices, scraping filings or synthesising reports.
+- **Sandbox** coordinates agents asynchronously using a shared event loop.
+- **TradeSuite Services** provide data access (InfluxDB, CCXT), rule evaluation and alerts.
+- **Storage** can be InfluxDB, SQLite or JSON files for persistent memory.
+
+## 2. Reusable Tools
+
+Existing functionality can be wrapped as agent actions:
+
+- `trade_suite.data.Data` for historical and real-time feeds.
+- `sentinel.alert_bot.manager.AlertDataManager` for rule definitions and triggers.
+- `scanner` tools for chart analysis and signal generation.
+- `cope_net` (planned) for natural language report generation.
+- GUI loggers or file outputs for visualisation.
+
+## 3. Agent Types
+
+- **MonitorAgent** – streams market data and updates internal state.
+- **ScraperAgent** – polls SEC filings or other external sources.
+- **SynthesisAgent** – creates summaries using LLM tools.
+
+Agents can spawn new tasks via the sandbox to pursue sub‑goals.
+
+## 4. Sandbox Environment
+
+A new `agent_playground` package provides:
+
+- `base.Agent` – abstract class with an async `run` method.
+- `agents.py` – example agents using TradeSuite modules.
+- `sandbox.py` – utility to run a collection of agents concurrently.
+- `README.md` – instructions for experimentation.
+
+## 5. Agent Memory
+
+Agents maintain a `memory` dictionary. For persistent state, they may read/write SQLite tables or InfluxDB measurements using existing clients. Simple JSON files can store plans between runs.
+
+## 6. Async Design
+
+Agents are executed with `asyncio.gather` to keep latency low. Shared objects such as `Data` or `AlertDataManager` remain in memory to avoid repeated setup costs.
+
+## 7. Future Growth
+
+LLM agents could modify their own prompts or spawn specialised children that inherit memory from the parent. Over time the sandbox can evolve into a self‑improving workflow manager.


### PR DESCRIPTION
## Summary
- document new AutoGen-style agent framework
- create `agent_playground` sandbox with minimal agent stubs
- link to playground documentation from README files

## Testing
- `pytest tests/unit -q` *(fails: ModuleNotFoundError: No module named 'trade_suite')*


------
https://chatgpt.com/codex/tasks/task_e_6851e453a82c832c942c90bb1b03e475