### PR TITLE
[TradeSuite] Introduce StreamManager for hot reload

### DIFF
--- a/docs/code_reviews/watch_trades_concurrency.md
+++ b/docs/code_reviews/watch_trades_concurrency.md
@@ -1,0 +1,67 @@
+# watch_trades Concurrency Review
+
+This note outlines how `Data.watch_trades` delegates to `Streamer.watch_trades` and how that
+function is reused by both the TradeSuite GUI and the Sentinel service.
+
+## Overview
+
+- `Data.watch_trades` is a thin wrapper that simply forwards all arguments
+to `Streamer.watch_trades`.
+- `Streamer.watch_trades` supports three output mechanisms:
+  - GUI updates via `SignalEmitter` when no `sink` or `queue` is provided.
+  - Direct async callbacks via a supplied `sink` function.
+  - Delivery through an `asyncio.Queue`.
+- Sentinel uses `sink` functions to pipe trades into its queues while the GUI
+relies on `SignalEmitter` emissions.
+
+## Potential Interactions
+
+If both systems share the same `Data` instance (as with
+`Data.initialize_sentinel()`), they call `watch_trades` independently.
+Each call maintains its own `asyncio.Event` and loop but operates on the
+same underlying CCXT exchange object.
+
+- Multiple tasks can therefore invoke `exchange.watch_trades(symbol)` at the
+  same time. CCXT-PRO generally supports this but it results in separate
+  consumer loops on the same WebSocket stream.
+- The GUI and Sentinel do not share queues or sinks, so their emitted data
+  remains isolated.
+- CPU and network load may increase when two watchers fetch the same market,
+  but no direct data corruption occurs within `Streamer.watch_trades`.
+
+## Recommendations
+
+- When running Sentinel alongside the GUI, prefer dedicated exchanges or
+  symbols where possible to avoid duplicate connections.
+- If both must observe the same market, be aware of the extra WebSocket load.
+  Consider adding a shared fan‑out layer in the future so that a single watcher
+  feeds multiple consumers.
+
+Overall the current implementation allows concurrent use, but resource
+usage grows with each separate `watch_trades` task on the same market.
+
+## Multi-Symbol Streaming and Hot Reload
+
+`Streamer.watch_trades_list` already calls `exchange.watchTradesForSymbols(symbols)`
+to subscribe to multiple markets in one WebSocket connection.  However the
+current TaskManager spins up individual `watch_trades` tasks per symbol.  This
+means adding or removing a symbol requires starting or stopping entire tasks and
+does not reuse a single feed.
+
+To support hot reloading we could maintain a symbol set per exchange and restart
+`watchTradesForSymbols` when that set changes.  The TaskManager would update the
+set whenever a widget subscribes or unsubscribes and signal the running stream to
+restart with the new list.  Alternatively a small facade around the CCXT exchange
+could manage the symbol list internally, exposing `add_symbol` and
+`remove_symbol` helpers that trigger `exchange.watchTradesForSymbols` with the
+updated list.  Either approach would allow dynamic subscription changes without
+opening a new socket for every symbol.
+
+## StreamManager Refactor
+
+The codebase now includes a `StreamManager` class extracted from `TaskManager`.
+It keeps per-exchange symbol sets and runs continuous
+`watchTradesForSymbols` and `watchOrderBookForSymbols` loops. Widgets call
+`subscribe_to_asset` or `unsubscribe_from_asset` to update these sets.  Because
+the loops read the latest symbol list each iteration, new markets can be added
+or removed at runtime without restarting the WebSocket connection.

--- a/trade_suite/gui/stream_manager.py
+++ b/trade_suite/gui/stream_manager.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections import defaultdict
+from typing import Dict, Set
+
+from trade_suite.gui.signals import Signals
+from trade_suite.data.data_source import Data
+
+
+class StreamManager:
+    """Manage hot-reloadable market data streams per exchange."""
+
+    def __init__(self, data: Data) -> None:
+        self.data = data
+        self.trade_symbols: Dict[str, Set[str]] = defaultdict(set)
+        self.orderbook_symbols: Dict[str, Set[str]] = defaultdict(set)
+        self.ref_counts: Dict[tuple[str, str, str], int] = defaultdict(int)
+        self._stop = asyncio.Event()
+        self._lock = asyncio.Lock()
+        self._tasks: list[asyncio.Task] = []
+
+    async def run(self) -> None:
+        """Run persistent watch loops for all exchanges."""
+        for exchange in self.data.exchange_list.keys():
+            self._tasks.append(asyncio.create_task(self._watch_trades_loop(exchange)))
+            self._tasks.append(asyncio.create_task(self._watch_order_books_loop(exchange)))
+        await self._stop.wait()
+        for task in self._tasks:
+            task.cancel()
+        await asyncio.gather(*self._tasks, return_exceptions=True)
+
+    async def stop(self) -> None:
+        self._stop.set()
+
+    async def subscribe_to_asset(self, exchange: str, symbol: str, stream_type: str) -> None:
+        """Increment ref count and add symbol to active list."""
+        key = (stream_type, exchange, symbol)
+        async with self._lock:
+            self.ref_counts[key] += 1
+            if stream_type == "trades":
+                self.trade_symbols[exchange].add(symbol)
+            elif stream_type == "orderbook":
+                self.orderbook_symbols[exchange].add(symbol)
+
+    async def unsubscribe_from_asset(self, exchange: str, symbol: str, stream_type: str) -> None:
+        """Decrement ref count and remove symbol if unused."""
+        key = (stream_type, exchange, symbol)
+        async with self._lock:
+            if self.ref_counts[key] > 0:
+                self.ref_counts[key] -= 1
+                if self.ref_counts[key] == 0:
+                    del self.ref_counts[key]
+                    if stream_type == "trades":
+                        self.trade_symbols[exchange].discard(symbol)
+                    elif stream_type == "orderbook":
+                        self.orderbook_symbols[exchange].discard(symbol)
+
+    async def _watch_trades_loop(self, exchange_id: str) -> None:
+        exchange = self.data.exchange_list[exchange_id]
+        logging.info(f"StreamManager trade loop for {exchange_id} started")
+        while not self._stop.is_set():
+            symbols = list(self.trade_symbols[exchange_id])
+            if not symbols:
+                await asyncio.sleep(0.5)
+                continue
+            try:
+                trades = await exchange.watchTradesForSymbols(symbols)
+                if trades:
+                    trade = trades[0]
+                    if self.data.streamer._ui_loop:
+                        self.data.emitter.emit_threadsafe(
+                            self.data.streamer._ui_loop,
+                            Signals.NEW_TRADE,
+                            exchange=exchange_id,
+                            trade_data=trade,
+                        )
+                    else:
+                        self.data.emitter.emit(
+                            Signals.NEW_TRADE,
+                            exchange=exchange_id,
+                            trade_data=trade,
+                        )
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                logging.error(f"Error in trade loop for {exchange_id}: {e}", exc_info=True)
+        logging.info(f"Trade loop for {exchange_id} stopped")
+
+    async def _watch_order_books_loop(self, exchange_id: str) -> None:
+        exchange = self.data.exchange_list[exchange_id]
+        logging.info(f"StreamManager order book loop for {exchange_id} started")
+        while not self._stop.is_set():
+            symbols = list(self.orderbook_symbols[exchange_id])
+            if not symbols:
+                await asyncio.sleep(0.5)
+                continue
+            try:
+                if exchange.has.get("watchOrderBookForSymbols"):
+                    orderbook = await exchange.watchOrderBookForSymbols(symbols)
+                    if orderbook:
+                        if self.data.streamer._ui_loop:
+                            self.data.emitter.emit_threadsafe(
+                                self.data.streamer._ui_loop,
+                                Signals.ORDER_BOOK_UPDATE,
+                                exchange=exchange_id,
+                                orderbook=orderbook,
+                            )
+                        else:
+                            self.data.emitter.emit(
+                                Signals.ORDER_BOOK_UPDATE,
+                                exchange=exchange_id,
+                                orderbook=orderbook,
+                            )
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                logging.error(f"Error in order book loop for {exchange_id}: {e}", exc_info=True)
+        logging.info(f"Order book loop for {exchange_id} stopped")


### PR DESCRIPTION
## Summary
- create `StreamManager` for centralized multi-symbol streaming
- hook TaskManager to start StreamManager loops
- delegate subscribe/unsubscribe logic to StreamManager
- document StreamManager approach in watch_trades concurrency note

## Testing
- `pytest -q` *(fails: Fatal Python error due to DearPyGui)*

------
https://chatgpt.com/codex/tasks/task_e_685326d13a34832c85600af3812b8029