### PR TITLE
[Docs] Reflect core facade architecture

### DIFF
--- a/docs/changelogs/feature_specific_changelogs/core-services-facade-refactor_6-18-2025.md
+++ b/docs/changelogs/feature_specific_changelogs/core-services-facade-refactor_6-18-2025.md
@@ -1,0 +1,13 @@
+# Core Services Facade Refactor
+
+**Date:** 2025-06-18
+
+## Summary
+
+The `TaskManager`, `SignalEmitter`, and `DataFacade` have been moved into a new `trade_suite.core` package. A `CoreServicesFacade` was introduced to initialize and wire these pieces together. This facade allows external clients such as the Sentinel alert bot to bootstrap TradeSuite's backend services without the GUI.
+
+## Impact
+
+* The main application and standalone tools now create a `CoreServicesFacade` instead of constructing each service manually.
+* Documentation and diagrams updated to reference the `trade_suite.core` modules.
+* Future features can import the facade to reuse TradeSuite's data streaming stack with minimal setup.

--- a/docs/changelogs/main_changelog.md
+++ b/docs/changelogs/main_changelog.md
@@ -2,6 +2,7 @@
 
 This project follows a loose changelog format. Significant entries:
 
+- **2025-06-18** Core services extracted to `trade_suite/core` with `CoreServicesFacade`
 - **2025-06-05** Data class modularized into DataFacade
 
 - **2025-05-11** CCXT initialization refactoring

--- a/docs/developer_guide/data_flow.md
+++ b/docs/developer_guide/data_flow.md
@@ -4,9 +4,11 @@ The TradeSuite data pipeline was completely overhauled as part of the
 `data_source_refactor` effort. Widgets subscribe to generic `StreamKey` values
 (`exchange`, `symbol`, `timeframe`) and the `TaskManager` maintains reference
 counts, running all async tasks in a dedicated event loop. A `DataFacade`
-(in `trade_suite/data/data_source.py`) now orchestrates `CacheStore`,
+(in `trade_suite/core/data/data_source.py`) now orchestrates `CacheStore`,
 `CandleFetcher`, and `Streamer` components, allowing multiple widgets to share a
 single WebSocket connection and centralizing cache and exchange logic.
+
+A new `CoreServicesFacade` in `trade_suite/core/facade.py` bundles `DataFacade`, `TaskManager` and `SignalEmitter` together so that headless clients like the Sentinel alert bot can initialize them with a single call.
 
 For in-depth rationale and migration details see
 [`design_documents/implemented_designs/data_source_refactor.md`](../design_documents/implemented_designs/data_source_refactor.md).

--- a/docs/user_guide/features/sentinel_alert_bot.md
+++ b/docs/user_guide/features/sentinel_alert_bot.md
@@ -6,10 +6,14 @@ graph TD
 
     subgraph TradeSuite_Core
         style TradeSuite_Core fill:#e1f5fe,stroke:#b3e5fc
-        TS_Data["DataFacade (data_source.py)"] -- Fetches/Streams --> Internet["Exchanges (CCXT Pro)"]
-        TS_TaskManager["TaskManager (task_manager.py)"]
-        TS_SignalEmitter["SignalEmitter (signals.py)"]
+        TS_CoreFacade["CoreServicesFacade (core/facade.py)"]
+        TS_Data["DataFacade (core/data/data_source.py)"] -- Fetches/Streams --> Internet["Exchanges (CCXT Pro)"]
+        TS_TaskManager["TaskManager (core/task_manager.py)"]
+        TS_SignalEmitter["SignalEmitter (core/signals.py)"]
         TS_CandleFactory["CandleFactory Instances"]
+        TS_CoreFacade --> TS_TaskManager
+        TS_CoreFacade --> TS_Data
+        TS_CoreFacade --> TS_SignalEmitter
         
         TS_TaskManager -- Manages Lifecycle --> TS_Data
         TS_TaskManager -- Manages Lifecycle --> TS_CandleFactory
@@ -43,7 +47,6 @@ graph TD
     TS_Data -- Emits NEW_TRADE, NEW_TICKER_DATA --> TS_SignalEmitter
     TS_CandleFactory -- Emits UPDATED_CANDLES --> TS_SignalEmitter
     TS_SignalEmitter -- Publishes Events --> ADM
-
     ADM -- Handles UPDATED_CANDLES --> AB_RuleLogic
     ADM -- Handles NEW_TRADE --> AB_Processors
     AB_Processors -- Updates State --> AB_Processors


### PR DESCRIPTION
## Summary
- document new CoreServicesFacade module in architecture and data flow docs
- update Sentinel Alert Bot diagram with new core paths
- note facade refactor in changelogs

## Testing
- `python -m trade_suite --help` *(fails: ImportError)*

------
https://chatgpt.com/codex/tasks/task_e_6853910144dc832c9fe1619db811fd16