### PR TITLE
Add provider-neutral equities bridge scaffolding with yfinance provider

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
   "aiofiles>=23.2.1",
   "tabulate>=0.9.0",
   "qtawesome>=1.4.1",
+  "yfinance>=0.2.55",
 ]
 
 [project.scripts]

--- a/sentinel/market/__init__.py
+++ b/sentinel/market/__init__.py
@@ -1,0 +1,13 @@
+"""Equities and market bridge subsystem."""
+
+from sentinel.market.models import BarSeries, CandleChartPayload, EquityInstrument, QuoteSnapshot
+from sentinel.market.query import HistoricalBarsQuery, Timeframe
+
+__all__ = [
+    "BarSeries",
+    "CandleChartPayload",
+    "EquityInstrument",
+    "HistoricalBarsQuery",
+    "QuoteSnapshot",
+    "Timeframe",
+]

--- a/sentinel/market/cache/__init__.py
+++ b/sentinel/market/cache/__init__.py
@@ -1,0 +1,1 @@
+"""cache package."""

--- a/sentinel/market/cache/base.py
+++ b/sentinel/market/cache/base.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+
+@dataclass(frozen=True, slots=True)
+class CacheEntry(Generic[T]):
+    value: T
+    created_at: datetime
+    ttl: timedelta
+
+    @property
+    def is_expired(self) -> bool:
+        return datetime.now(timezone.utc) >= self.created_at + self.ttl
+
+
+class CacheStore(ABC, Generic[T]):
+    @abstractmethod
+    def get(self, key: str) -> T | None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def put(self, key: str, value: T, ttl: timedelta) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def invalidate(self, key: str) -> None:
+        raise NotImplementedError

--- a/sentinel/market/cache/memory_cache.py
+++ b/sentinel/market/cache/memory_cache.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from sentinel.market.cache.base import CacheEntry, CacheStore, T
+
+
+class InMemoryCacheStore(CacheStore[T]):
+    def __init__(self) -> None:
+        self._store: dict[str, CacheEntry[T]] = {}
+
+    def get(self, key: str) -> T | None:
+        entry = self._store.get(key)
+        if entry is None:
+            return None
+        if entry.is_expired:
+            self._store.pop(key, None)
+            return None
+        return entry.value
+
+    def put(self, key: str, value: T, ttl: timedelta) -> None:
+        self._store[key] = CacheEntry(
+            value=value,
+            created_at=datetime.now(timezone.utc),
+            ttl=ttl,
+        )
+
+    def invalidate(self, key: str) -> None:
+        self._store.pop(key, None)

--- a/sentinel/market/models.py
+++ b/sentinel/market/models.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import Mapping, Sequence
+
+
+class AssetClass(str, Enum):
+    EQUITY = "equity"
+    ETF = "etf"
+    INDEX = "index"
+    ADR = "adr"
+    UNKNOWN = "unknown"
+
+
+class CorporateActionType(str, Enum):
+    DIVIDEND = "dividend"
+    SPLIT = "split"
+    EARNINGS = "earnings"
+
+
+@dataclass(frozen=True, slots=True)
+class EquityInstrument:
+    symbol: str
+    name: str | None = None
+    exchange: str | None = None
+    currency: str | None = None
+    timezone: str | None = None
+    asset_class: AssetClass = AssetClass.UNKNOWN
+    provider_symbol: str | None = None
+    primary_mic: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class Bar:
+    ts: datetime
+    open: float
+    high: float
+    low: float
+    close: float
+    volume: float | None = None
+    vwap: float | None = None
+    trade_count: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class BarSeries:
+    symbol: str
+    interval: str
+    timezone: str
+    bars: tuple[Bar, ...]
+    adjusted: bool
+    include_extended_hours: bool
+    metadata: Mapping[str, str] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class QuoteSnapshot:
+    symbol: str
+    timestamp: datetime | None
+    last: float | None
+    bid: float | None = None
+    ask: float | None = None
+    open: float | None = None
+    high: float | None = None
+    low: float | None = None
+    previous_close: float | None = None
+    volume: float | None = None
+    currency: str | None = None
+    market_state: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class CorporateAction:
+    symbol: str
+    action_type: CorporateActionType
+    ex_date: datetime
+    value: float | None = None
+    ratio_from: float | None = None
+    ratio_to: float | None = None
+    description: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class CompanyProfile:
+    symbol: str
+    display_name: str | None = None
+    long_business_summary: str | None = None
+    sector: str | None = None
+    industry: str | None = None
+    country: str | None = None
+    website: str | None = None
+    market_cap: float | None = None
+    employee_count: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class NewsItem:
+    symbol: str
+    headline: str
+    publisher: str | None
+    url: str | None
+    published_at: datetime | None
+    summary: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class Marker:
+    ts: datetime
+    label: str
+    kind: str
+    value: float | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class CandleChartPayload:
+    symbol: str
+    interval: str
+    timezone: str
+    x: tuple[float, ...]
+    opens: tuple[float, ...]
+    highs: tuple[float, ...]
+    lows: tuple[float, ...]
+    closes: tuple[float, ...]
+    volumes: tuple[float | None, ...]
+    price_min: float | None
+    price_max: float | None
+    markers: Sequence[Marker] = field(default_factory=tuple)
+    overlays: Mapping[str, Sequence[float]] = field(default_factory=dict)

--- a/sentinel/market/normalization/__init__.py
+++ b/sentinel/market/normalization/__init__.py
@@ -1,0 +1,1 @@
+"""normalization package."""

--- a/sentinel/market/normalization/equity_normalizer.py
+++ b/sentinel/market/normalization/equity_normalizer.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+import pandas as pd
+
+from sentinel.market.models import Bar, BarSeries, CorporateAction, CorporateActionType
+
+
+OHLC_RENAME_MAP = {
+    "Open": "open",
+    "High": "high",
+    "Low": "low",
+    "Close": "close",
+    "Adj Close": "adj_close",
+    "Volume": "volume",
+}
+
+
+class EquityNormalizer:
+    def normalize_bars(
+        self,
+        *,
+        symbol: str,
+        interval: str,
+        timezone_name: str,
+        raw_history: pd.DataFrame,
+        adjusted: bool,
+        include_extended_hours: bool,
+    ) -> BarSeries:
+        if raw_history.empty:
+            return BarSeries(
+                symbol=symbol,
+                interval=interval,
+                timezone=timezone_name,
+                bars=tuple(),
+                adjusted=adjusted,
+                include_extended_hours=include_extended_hours,
+            )
+
+        df = raw_history.rename(columns=OHLC_RENAME_MAP).copy()
+        df = df[~df.index.duplicated(keep="last")]
+        df = df.sort_index()
+
+        for column in ("open", "high", "low", "close"):
+            df[column] = pd.to_numeric(df[column], errors="coerce")
+        if "volume" in df.columns:
+            df["volume"] = pd.to_numeric(df["volume"], errors="coerce")
+
+        df = df.dropna(subset=["open", "high", "low", "close"])
+
+        bars: list[Bar] = []
+        for index, row in df.iterrows():
+            ts = self._as_datetime(index)
+            close_value = row["adj_close"] if adjusted and "adj_close" in row and pd.notna(row["adj_close"]) else row["close"]
+            bars.append(
+                Bar(
+                    ts=ts,
+                    open=float(row["open"]),
+                    high=float(row["high"]),
+                    low=float(row["low"]),
+                    close=float(close_value),
+                    volume=float(row["volume"]) if "volume" in row and pd.notna(row["volume"]) else None,
+                )
+            )
+
+        return BarSeries(
+            symbol=symbol,
+            interval=interval,
+            timezone=timezone_name,
+            bars=tuple(bars),
+            adjusted=adjusted,
+            include_extended_hours=include_extended_hours,
+        )
+
+    def normalize_actions(
+        self,
+        *,
+        symbol: str,
+        dividends: pd.Series | None,
+        splits: pd.Series | None,
+    ) -> list[CorporateAction]:
+        actions: list[CorporateAction] = []
+        if dividends is not None and not dividends.empty:
+            for idx, value in dividends.items():
+                actions.append(
+                    CorporateAction(
+                        symbol=symbol,
+                        action_type=CorporateActionType.DIVIDEND,
+                        ex_date=self._as_datetime(idx),
+                        value=float(value),
+                    )
+                )
+
+        if splits is not None and not splits.empty:
+            for idx, value in splits.items():
+                ratio_from, ratio_to = self._split_ratio(float(value))
+                actions.append(
+                    CorporateAction(
+                        symbol=symbol,
+                        action_type=CorporateActionType.SPLIT,
+                        ex_date=self._as_datetime(idx),
+                        ratio_from=ratio_from,
+                        ratio_to=ratio_to,
+                        value=float(value),
+                    )
+                )
+
+        return sorted(actions, key=lambda x: x.ex_date)
+
+    @staticmethod
+    def _as_datetime(value: Any) -> datetime:
+        ts = pd.Timestamp(value)
+        if ts.tzinfo is None:
+            ts = ts.tz_localize("UTC")
+        else:
+            ts = ts.tz_convert("UTC")
+        return ts.to_pydatetime()
+
+    @staticmethod
+    def _split_ratio(ratio: float) -> tuple[float, float]:
+        if ratio <= 0:
+            return (1.0, 1.0)
+        return (1.0, ratio)

--- a/sentinel/market/normalization/equity_normalizer.py
+++ b/sentinel/market/normalization/equity_normalizer.py
@@ -50,18 +50,33 @@ class EquityNormalizer:
 
         df = df.dropna(subset=["open", "high", "low", "close"])
 
+        indices = df.index.to_list()
+        opens = df["open"].to_numpy()
+        highs = df["high"].to_numpy()
+        lows = df["low"].to_numpy()
+        closes = (
+            df["adj_close"].to_numpy()
+            if adjusted and "adj_close" in df.columns
+            else df["close"].to_numpy()
+        )
+        volumes = df["volume"].to_numpy() if "volume" in df.columns else None
+
         bars: list[Bar] = []
-        for index, row in df.iterrows():
-            ts = self._as_datetime(index)
-            close_value = row["adj_close"] if adjusted and "adj_close" in row and pd.notna(row["adj_close"]) else row["close"]
+        for row_index, (idx, open_price, high_price, low_price, close_price) in enumerate(
+            zip(indices, opens, highs, lows, closes)
+        ):
+            ts = self._as_datetime(idx)
+            volume = None
+            if volumes is not None and pd.notna(volumes[row_index]):
+                volume = float(volumes[row_index])
             bars.append(
                 Bar(
                     ts=ts,
-                    open=float(row["open"]),
-                    high=float(row["high"]),
-                    low=float(row["low"]),
-                    close=float(close_value),
-                    volume=float(row["volume"]) if "volume" in row and pd.notna(row["volume"]) else None,
+                    open=float(open_price),
+                    high=float(high_price),
+                    low=float(low_price),
+                    close=float(close_price),
+                    volume=volume,
                 )
             )
 

--- a/sentinel/market/prep/__init__.py
+++ b/sentinel/market/prep/__init__.py
@@ -1,0 +1,1 @@
+"""prep package."""

--- a/sentinel/market/prep/chart_payload_builder.py
+++ b/sentinel/market/prep/chart_payload_builder.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from sentinel.market.models import BarSeries, CandleChartPayload, CorporateAction, Marker
+
+
+class CandleChartPayloadBuilder:
+    def build(self, bar_series: BarSeries, actions: list[CorporateAction] | None = None) -> CandleChartPayload:
+        bars = bar_series.bars
+        x = tuple(bar.ts.timestamp() for bar in bars)
+        opens = tuple(bar.open for bar in bars)
+        highs = tuple(bar.high for bar in bars)
+        lows = tuple(bar.low for bar in bars)
+        closes = tuple(bar.close for bar in bars)
+        volumes = tuple(bar.volume for bar in bars)
+
+        markers: list[Marker] = []
+        if actions:
+            for action in actions:
+                markers.append(
+                    Marker(
+                        ts=action.ex_date,
+                        label=action.action_type.value,
+                        kind="corporate_action",
+                        value=action.value,
+                    )
+                )
+
+        return CandleChartPayload(
+            symbol=bar_series.symbol,
+            interval=bar_series.interval,
+            timezone=bar_series.timezone,
+            x=x,
+            opens=opens,
+            highs=highs,
+            lows=lows,
+            closes=closes,
+            volumes=volumes,
+            price_min=min(lows) if lows else None,
+            price_max=max(highs) if highs else None,
+            markers=tuple(markers),
+        )

--- a/sentinel/market/providers/__init__.py
+++ b/sentinel/market/providers/__init__.py
@@ -1,0 +1,1 @@
+"""providers package."""

--- a/sentinel/market/providers/base.py
+++ b/sentinel/market/providers/base.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from sentinel.market.models import (
+    BarSeries,
+    CompanyProfile,
+    CorporateAction,
+    EquityInstrument,
+    NewsItem,
+    QuoteSnapshot,
+)
+from sentinel.market.query import HistoricalBarsQuery
+
+
+class EquityProvider(ABC):
+    provider_name: str
+
+    @abstractmethod
+    async def search_symbol(self, text: str, limit: int = 10) -> list[EquityInstrument]:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def resolve_symbol(self, symbol: str) -> EquityInstrument | None:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def get_company_profile(self, symbol: str) -> CompanyProfile | None:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def get_quote_snapshot(self, symbol: str) -> QuoteSnapshot | None:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def get_historical_bars(self, query: HistoricalBarsQuery) -> BarSeries:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def get_corporate_actions(
+        self,
+        symbol: str,
+        *,
+        start=None,
+        end=None,
+    ) -> list[CorporateAction]:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def get_news(self, symbol: str, limit: int = 20) -> list[NewsItem]:
+        raise NotImplementedError

--- a/sentinel/market/providers/yfinance_provider.py
+++ b/sentinel/market/providers/yfinance_provider.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+
+from sentinel.market.models import (
+    AssetClass,
+    BarSeries,
+    CompanyProfile,
+    CorporateAction,
+    EquityInstrument,
+    NewsItem,
+    QuoteSnapshot,
+)
+from sentinel.market.normalization.equity_normalizer import EquityNormalizer
+from sentinel.market.providers.base import EquityProvider
+from sentinel.market.query import HistoricalBarsQuery, validate_yfinance_range
+
+
+class YFinanceEquityProvider(EquityProvider):
+    provider_name = "yfinance"
+
+    def __init__(self, normalizer: EquityNormalizer | None = None) -> None:
+        self._normalizer = normalizer or EquityNormalizer()
+
+    async def search_symbol(self, text: str, limit: int = 10) -> list[EquityInstrument]:
+        # yfinance does not provide a robust search endpoint.
+        # Keep this provider-neutral seam so another provider can support real discovery.
+        if not text.strip():
+            return []
+        resolved = await self.resolve_symbol(text.strip().upper())
+        return [resolved] if resolved else []
+
+    async def resolve_symbol(self, symbol: str) -> EquityInstrument | None:
+        ticker = await self._ticker(symbol)
+        info = await asyncio.to_thread(lambda: ticker.fast_info or {})
+        if not info:
+            return EquityInstrument(symbol=symbol, provider_symbol=symbol)
+        return EquityInstrument(
+            symbol=symbol,
+            provider_symbol=symbol,
+            exchange=info.get("exchange"),
+            currency=info.get("currency"),
+            timezone=info.get("timezone"),
+            asset_class=AssetClass.EQUITY,
+        )
+
+    async def get_company_profile(self, symbol: str) -> CompanyProfile | None:
+        ticker = await self._ticker(symbol)
+        info = await asyncio.to_thread(lambda: ticker.info or {})
+        if not info:
+            return None
+        return CompanyProfile(
+            symbol=symbol,
+            display_name=info.get("longName") or info.get("shortName"),
+            long_business_summary=info.get("longBusinessSummary"),
+            sector=info.get("sector"),
+            industry=info.get("industry"),
+            country=info.get("country"),
+            website=info.get("website"),
+            market_cap=float(info["marketCap"]) if info.get("marketCap") else None,
+            employee_count=int(info["fullTimeEmployees"]) if info.get("fullTimeEmployees") else None,
+        )
+
+    async def get_quote_snapshot(self, symbol: str) -> QuoteSnapshot | None:
+        ticker = await self._ticker(symbol)
+        info = await asyncio.to_thread(lambda: ticker.fast_info or {})
+        if not info:
+            return None
+        return QuoteSnapshot(
+            symbol=symbol,
+            timestamp=datetime.utcnow(),
+            last=_as_float(info.get("lastPrice")),
+            bid=_as_float(info.get("bid")),
+            ask=_as_float(info.get("ask")),
+            open=_as_float(info.get("open")),
+            high=_as_float(info.get("dayHigh")),
+            low=_as_float(info.get("dayLow")),
+            previous_close=_as_float(info.get("previousClose")),
+            volume=_as_float(info.get("lastVolume")),
+            currency=info.get("currency"),
+            market_state=info.get("marketState"),
+        )
+
+    async def get_historical_bars(self, query: HistoricalBarsQuery) -> BarSeries:
+        validate_yfinance_range(query)
+        ticker = await self._ticker(query.symbol)
+
+        history = await asyncio.to_thread(
+            ticker.history,
+            interval=query.interval.value,
+            start=query.start,
+            end=query.end,
+            period=query.period,
+            auto_adjust=query.adjusted,
+            prepost=query.include_extended_hours,
+            actions=False,
+        )
+
+        return self._normalizer.normalize_bars(
+            symbol=query.symbol,
+            interval=query.interval.value,
+            timezone_name=query.output_timezone,
+            raw_history=history,
+            adjusted=query.adjusted,
+            include_extended_hours=query.include_extended_hours,
+        )
+
+    async def get_corporate_actions(
+        self,
+        symbol: str,
+        *,
+        start=None,
+        end=None,
+    ) -> list[CorporateAction]:
+        ticker = await self._ticker(symbol)
+        dividends = await asyncio.to_thread(lambda: ticker.dividends)
+        splits = await asyncio.to_thread(lambda: ticker.splits)
+        actions = self._normalizer.normalize_actions(symbol=symbol, dividends=dividends, splits=splits)
+        if start or end:
+            return [a for a in actions if (not start or a.ex_date >= start) and (not end or a.ex_date <= end)]
+        return actions
+
+    async def get_news(self, symbol: str, limit: int = 20) -> list[NewsItem]:
+        ticker = await self._ticker(symbol)
+        raw_news = await asyncio.to_thread(lambda: ticker.news or [])
+        items: list[NewsItem] = []
+        for article in raw_news[:limit]:
+            items.append(
+                NewsItem(
+                    symbol=symbol,
+                    headline=article.get("title", ""),
+                    publisher=article.get("publisher"),
+                    url=article.get("link"),
+                    published_at=datetime.utcfromtimestamp(article["providerPublishTime"])
+                    if article.get("providerPublishTime")
+                    else None,
+                    summary=article.get("summary"),
+                )
+            )
+        return items
+
+    async def _ticker(self, symbol: str):
+        import yfinance as yf
+
+        return await asyncio.to_thread(yf.Ticker, symbol)
+
+
+def _as_float(value) -> float | None:
+    try:
+        return float(value) if value is not None else None
+    except (TypeError, ValueError):
+        return None

--- a/sentinel/market/providers/yfinance_provider.py
+++ b/sentinel/market/providers/yfinance_provider.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import datetime
+from datetime import datetime, timezone
+
+import yfinance as yf
 
 from sentinel.market.models import (
     AssetClass,
@@ -33,15 +35,15 @@ class YFinanceEquityProvider(EquityProvider):
 
     async def resolve_symbol(self, symbol: str) -> EquityInstrument | None:
         ticker = await self._ticker(symbol)
-        info = await asyncio.to_thread(lambda: ticker.fast_info or {})
-        if not info:
+        fast_info = await asyncio.to_thread(lambda: ticker.fast_info)
+        if fast_info is None:
             return EquityInstrument(symbol=symbol, provider_symbol=symbol)
         return EquityInstrument(
             symbol=symbol,
             provider_symbol=symbol,
-            exchange=info.get("exchange"),
-            currency=info.get("currency"),
-            timezone=info.get("timezone"),
+            exchange=_fast_info_attr(fast_info, "exchange"),
+            currency=_fast_info_attr(fast_info, "currency"),
+            timezone=_fast_info_attr(fast_info, "timezone"),
             asset_class=AssetClass.EQUITY,
         )
 
@@ -64,22 +66,23 @@ class YFinanceEquityProvider(EquityProvider):
 
     async def get_quote_snapshot(self, symbol: str) -> QuoteSnapshot | None:
         ticker = await self._ticker(symbol)
-        info = await asyncio.to_thread(lambda: ticker.fast_info or {})
-        if not info:
+        fast_info = await asyncio.to_thread(lambda: ticker.fast_info)
+        if fast_info is None:
             return None
+        slow_info = await asyncio.to_thread(lambda: ticker.info or {})
         return QuoteSnapshot(
             symbol=symbol,
-            timestamp=datetime.utcnow(),
-            last=_as_float(info.get("lastPrice")),
-            bid=_as_float(info.get("bid")),
-            ask=_as_float(info.get("ask")),
-            open=_as_float(info.get("open")),
-            high=_as_float(info.get("dayHigh")),
-            low=_as_float(info.get("dayLow")),
-            previous_close=_as_float(info.get("previousClose")),
-            volume=_as_float(info.get("lastVolume")),
-            currency=info.get("currency"),
-            market_state=info.get("marketState"),
+            timestamp=datetime.now(timezone.utc),
+            last=_as_float(_fast_info_attr(fast_info, "last_price")),
+            bid=_as_float(slow_info.get("bid")),
+            ask=_as_float(slow_info.get("ask")),
+            open=_as_float(_fast_info_attr(fast_info, "open")),
+            high=_as_float(_fast_info_attr(fast_info, "day_high")),
+            low=_as_float(_fast_info_attr(fast_info, "day_low")),
+            previous_close=_as_float(_fast_info_attr(fast_info, "previous_close")),
+            volume=_as_float(_fast_info_attr(fast_info, "last_volume")),
+            currency=_fast_info_attr(fast_info, "currency"),
+            market_state=slow_info.get("marketState"),
         )
 
     async def get_historical_bars(self, query: HistoricalBarsQuery) -> BarSeries:
@@ -132,7 +135,7 @@ class YFinanceEquityProvider(EquityProvider):
                     headline=article.get("title", ""),
                     publisher=article.get("publisher"),
                     url=article.get("link"),
-                    published_at=datetime.utcfromtimestamp(article["providerPublishTime"])
+                    published_at=datetime.fromtimestamp(article["providerPublishTime"], tz=timezone.utc)
                     if article.get("providerPublishTime")
                     else None,
                     summary=article.get("summary"),
@@ -141,9 +144,7 @@ class YFinanceEquityProvider(EquityProvider):
         return items
 
     async def _ticker(self, symbol: str):
-        import yfinance as yf
-
-        return await asyncio.to_thread(yf.Ticker, symbol)
+        return yf.Ticker(symbol)
 
 
 def _as_float(value) -> float | None:
@@ -151,3 +152,13 @@ def _as_float(value) -> float | None:
         return float(value) if value is not None else None
     except (TypeError, ValueError):
         return None
+
+
+def _fast_info_attr(fast_info: object, name: str):
+    value = getattr(fast_info, name, None)
+    if value is None and hasattr(fast_info, "__getitem__"):
+        try:
+            return fast_info[name]
+        except Exception:
+            return None
+    return value

--- a/sentinel/market/query.py
+++ b/sentinel/market/query.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from enum import Enum
+
+
+class QueryValidationError(ValueError):
+    """Raised when a historical query cannot be satisfied."""
+
+
+class Timeframe(str, Enum):
+    M1 = "1m"
+    M2 = "2m"
+    M5 = "5m"
+    M15 = "15m"
+    M30 = "30m"
+    H1 = "1h"
+    D1 = "1d"
+    W1 = "1wk"
+    MO1 = "1mo"
+
+
+@dataclass(frozen=True, slots=True)
+class HistoricalBarsQuery:
+    symbol: str
+    interval: Timeframe
+    start: datetime | None = None
+    end: datetime | None = None
+    period: str | None = None
+    adjusted: bool = True
+    include_extended_hours: bool = False
+    output_timezone: str = "UTC"
+
+    def validate(self, now: datetime | None = None) -> None:
+        if not self.symbol.strip():
+            raise QueryValidationError("symbol cannot be empty")
+
+        if self.start and self.end and self.start >= self.end:
+            raise QueryValidationError("start must be before end")
+
+        if self.period and (self.start or self.end):
+            raise QueryValidationError("use either period or start/end, not both")
+
+        if not self.period and not self.start:
+            raise QueryValidationError("start is required when period is not set")
+
+        if now is None:
+            now = datetime.now(timezone.utc)
+
+        if self.start and self.start > now + timedelta(minutes=1):
+            raise QueryValidationError("start cannot be in the future")
+
+
+YF_SUPPORTED_INTERVALS: dict[Timeframe, timedelta] = {
+    Timeframe.M1: timedelta(days=7),
+    Timeframe.M2: timedelta(days=60),
+    Timeframe.M5: timedelta(days=60),
+    Timeframe.M15: timedelta(days=60),
+    Timeframe.M30: timedelta(days=60),
+    Timeframe.H1: timedelta(days=730),
+    Timeframe.D1: timedelta(days=3650),
+    Timeframe.W1: timedelta(days=3650),
+    Timeframe.MO1: timedelta(days=7300),
+}
+
+
+def validate_yfinance_range(query: HistoricalBarsQuery, now: datetime | None = None) -> None:
+    query.validate(now=now)
+    if query.period:
+        return
+
+    if query.start is None:
+        return
+
+    if now is None:
+        now = datetime.now(timezone.utc)
+
+    max_span = YF_SUPPORTED_INTERVALS[query.interval]
+    if now - query.start > max_span:
+        raise QueryValidationError(
+            f"yfinance interval {query.interval.value} supports up to {max_span.days} days"
+        )

--- a/sentinel/market/services/__init__.py
+++ b/sentinel/market/services/__init__.py
@@ -1,0 +1,1 @@
+"""services package."""

--- a/sentinel/market/services/equities_service.py
+++ b/sentinel/market/services/equities_service.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from datetime import timedelta
+
+from sentinel.market.cache.base import CacheStore
+from sentinel.market.models import BarSeries, CorporateAction, QuoteSnapshot
+from sentinel.market.providers.base import EquityProvider
+from sentinel.market.query import HistoricalBarsQuery
+
+
+class EquitiesService:
+    def __init__(
+        self,
+        *,
+        provider: EquityProvider,
+        bar_cache: CacheStore[BarSeries],
+        quote_cache: CacheStore[QuoteSnapshot],
+    ) -> None:
+        self._provider = provider
+        self._bar_cache = bar_cache
+        self._quote_cache = quote_cache
+
+    async def get_historical_bars(self, query: HistoricalBarsQuery, *, force_refresh: bool = False) -> BarSeries:
+        key = self._bars_cache_key(query)
+        if not force_refresh:
+            cached = self._bar_cache.get(key)
+            if cached is not None:
+                return cached
+
+        bars = await self._provider.get_historical_bars(query)
+        ttl = timedelta(minutes=2 if query.interval.value.endswith("m") or query.interval.value.endswith("h") else 30)
+        self._bar_cache.put(key, bars, ttl)
+        return bars
+
+    async def get_quote_snapshot(self, symbol: str, *, force_refresh: bool = False) -> QuoteSnapshot | None:
+        key = f"quote:{symbol.upper()}"
+        if not force_refresh:
+            cached = self._quote_cache.get(key)
+            if cached is not None:
+                return cached
+
+        quote = await self._provider.get_quote_snapshot(symbol)
+        if quote is not None:
+            self._quote_cache.put(key, quote, timedelta(seconds=15))
+        return quote
+
+    async def get_corporate_actions(
+        self,
+        symbol: str,
+        *,
+        start=None,
+        end=None,
+    ) -> list[CorporateAction]:
+        return await self._provider.get_corporate_actions(symbol, start=start, end=end)
+
+    @staticmethod
+    def _bars_cache_key(query: HistoricalBarsQuery) -> str:
+        return "|".join(
+            [
+                "bars",
+                query.symbol.upper(),
+                query.interval.value,
+                query.start.isoformat() if query.start else "",
+                query.end.isoformat() if query.end else "",
+                query.period or "",
+                "adj" if query.adjusted else "raw",
+                "ext" if query.include_extended_hours else "rth",
+                query.output_timezone,
+            ]
+        )

--- a/sentinel/market/viewmodels/__init__.py
+++ b/sentinel/market/viewmodels/__init__.py
@@ -1,0 +1,1 @@
+"""viewmodels package."""

--- a/sentinel/market/viewmodels/equity_chart_viewmodel.py
+++ b/sentinel/market/viewmodels/equity_chart_viewmodel.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+
+from PySide6.QtCore import QObject, Signal
+
+from sentinel.market.prep.chart_payload_builder import CandleChartPayloadBuilder
+from sentinel.market.query import HistoricalBarsQuery, Timeframe
+from sentinel.market.services.equities_service import EquitiesService
+
+
+class EquityChartViewModel(QObject):
+    loading_changed = Signal(bool)
+    payload_ready = Signal(object)
+    error_changed = Signal(str)
+    empty_changed = Signal(bool)
+
+    def __init__(self, service: EquitiesService, parent: QObject | None = None) -> None:
+        super().__init__(parent)
+        self._service = service
+        self._payload_builder = CandleChartPayloadBuilder()
+        self._last_request_id = 0
+
+    def request_symbol(self, symbol: str, timeframe: Timeframe, *, days: int = 30) -> None:
+        self._last_request_id += 1
+        request_id = self._last_request_id
+        self.loading_changed.emit(True)
+        self.error_changed.emit("")
+        asyncio.create_task(self._load(request_id=request_id, symbol=symbol, timeframe=timeframe, days=days))
+
+    async def _load(self, *, request_id: int, symbol: str, timeframe: Timeframe, days: int) -> None:
+        try:
+            now = datetime.now(timezone.utc)
+            query = HistoricalBarsQuery(
+                symbol=symbol,
+                interval=timeframe,
+                start=now - timedelta(days=days),
+                end=now,
+            )
+            bars = await self._service.get_historical_bars(query)
+            actions = await self._service.get_corporate_actions(symbol, start=query.start, end=query.end)
+            payload = self._payload_builder.build(bars, actions)
+
+            if request_id != self._last_request_id:
+                return
+
+            self.empty_changed.emit(len(payload.x) == 0)
+            self.payload_ready.emit(payload)
+        except Exception as exc:
+            if request_id == self._last_request_id:
+                self.error_changed.emit(str(exc))
+        finally:
+            if request_id == self._last_request_id:
+                self.loading_changed.emit(False)

--- a/sentinel/market/viewmodels/equity_chart_viewmodel.py
+++ b/sentinel/market/viewmodels/equity_chart_viewmodel.py
@@ -21,13 +21,18 @@ class EquityChartViewModel(QObject):
         self._service = service
         self._payload_builder = CandleChartPayloadBuilder()
         self._last_request_id = 0
+        self._active_task: asyncio.Task | None = None
 
     def request_symbol(self, symbol: str, timeframe: Timeframe, *, days: int = 30) -> None:
+        if self._active_task and not self._active_task.done():
+            self._active_task.cancel()
         self._last_request_id += 1
         request_id = self._last_request_id
         self.loading_changed.emit(True)
         self.error_changed.emit("")
-        asyncio.create_task(self._load(request_id=request_id, symbol=symbol, timeframe=timeframe, days=days))
+        self._active_task = asyncio.create_task(
+            self._load(request_id=request_id, symbol=symbol, timeframe=timeframe, days=days)
+        )
 
     async def _load(self, *, request_id: int, symbol: str, timeframe: Timeframe, days: int) -> None:
         try:
@@ -47,6 +52,8 @@ class EquityChartViewModel(QObject):
 
             self.empty_changed.emit(len(payload.x) == 0)
             self.payload_ready.emit(payload)
+        except asyncio.CancelledError:
+            return
         except Exception as exc:
             if request_id == self._last_request_id:
                 self.error_changed.emit(str(exc))

--- a/tests/unit/test_equities_chart_payload.py
+++ b/tests/unit/test_equities_chart_payload.py
@@ -1,0 +1,34 @@
+from datetime import datetime, timezone
+
+from sentinel.market.models import Bar, BarSeries, CorporateAction, CorporateActionType
+from sentinel.market.prep.chart_payload_builder import CandleChartPayloadBuilder
+
+
+def test_chart_payload_builder_includes_action_markers() -> None:
+    bars = (
+        Bar(ts=datetime(2026, 1, 1, tzinfo=timezone.utc), open=10, high=11, low=9, close=10.5, volume=1000),
+        Bar(ts=datetime(2026, 1, 2, tzinfo=timezone.utc), open=10.5, high=12, low=10, close=11.5, volume=1200),
+    )
+    series = BarSeries(
+        symbol="AAPL",
+        interval="1d",
+        timezone="UTC",
+        bars=bars,
+        adjusted=True,
+        include_extended_hours=False,
+    )
+    actions = [
+        CorporateAction(
+            symbol="AAPL",
+            action_type=CorporateActionType.DIVIDEND,
+            ex_date=datetime(2026, 1, 2, tzinfo=timezone.utc),
+            value=0.2,
+        )
+    ]
+
+    payload = CandleChartPayloadBuilder().build(series, actions)
+
+    assert payload.price_min == 9
+    assert payload.price_max == 12
+    assert len(payload.markers) == 1
+    assert payload.markers[0].label == "dividend"

--- a/tests/unit/test_equities_normalization.py
+++ b/tests/unit/test_equities_normalization.py
@@ -1,0 +1,39 @@
+from datetime import datetime, timezone
+
+import pandas as pd
+
+from sentinel.market.normalization.equity_normalizer import EquityNormalizer
+
+
+def test_normalize_bars_sorts_and_deduplicates() -> None:
+    index = pd.to_datetime(
+        [
+            "2026-01-02T00:00:00Z",
+            "2026-01-01T00:00:00Z",
+            "2026-01-01T00:00:00Z",
+        ]
+    )
+    df = pd.DataFrame(
+        {
+            "Open": [10.0, 9.0, 9.1],
+            "High": [11.0, 10.0, 10.1],
+            "Low": [9.0, 8.0, 8.1],
+            "Close": [10.5, 9.5, 9.6],
+            "Volume": [100, 200, 300],
+        },
+        index=index,
+    )
+
+    normalizer = EquityNormalizer()
+    series = normalizer.normalize_bars(
+        symbol="AAPL",
+        interval="1d",
+        timezone_name="UTC",
+        raw_history=df,
+        adjusted=False,
+        include_extended_hours=False,
+    )
+
+    assert len(series.bars) == 2
+    assert series.bars[0].ts == datetime(2026, 1, 1, tzinfo=timezone.utc)
+    assert series.bars[0].open == 9.1

--- a/tests/unit/test_equities_query.py
+++ b/tests/unit/test_equities_query.py
@@ -1,0 +1,28 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from sentinel.market.query import HistoricalBarsQuery, QueryValidationError, Timeframe, validate_yfinance_range
+
+
+def test_query_rejects_period_and_range_mix() -> None:
+    query = HistoricalBarsQuery(
+        symbol="AAPL",
+        interval=Timeframe.D1,
+        start=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        period="1mo",
+    )
+    with pytest.raises(QueryValidationError):
+        query.validate(now=datetime(2026, 1, 2, tzinfo=timezone.utc))
+
+
+def test_validate_yfinance_range_rejects_old_intraday() -> None:
+    now = datetime(2026, 4, 13, tzinfo=timezone.utc)
+    query = HistoricalBarsQuery(
+        symbol="AAPL",
+        interval=Timeframe.M1,
+        start=now - timedelta(days=30),
+        end=now,
+    )
+    with pytest.raises(QueryValidationError):
+        validate_yfinance_range(query, now=now)


### PR DESCRIPTION
### Motivation
- Introduce a provider-neutral equities bridge to power candle charts and future equities features without coupling UI widgets to yfinance or pandas. 
- Provide clean, typed domain models and clear seams (provider -> normalization -> cache -> service -> chart prep -> viewmodel) so other providers or live feeds can be added later. 

### Description
- Add a new `sentinel.market` subsystem with typed domain models in `sentinel/market/models.py` for `EquityInstrument`, `Bar`, `BarSeries`, `QuoteSnapshot`, `CorporateAction`, `CompanyProfile`, `NewsItem`, `Marker`, and `CandleChartPayload`. 
- Implement historical query contract and yfinance-range guardrails in `sentinel/market/query.py` and a typed `EquityProvider` abstract interface in `sentinel/market/providers/base.py`. 
- Add a `YFinanceEquityProvider` adapter in `sentinel/market/providers/yfinance_provider.py` that runs blocking yfinance calls via `asyncio.to_thread` and returns normalized models. 
- Add normalization (`EquityNormalizer`) in `sentinel/market/normalization/equity_normalizer.py` to canonicalize columns, deduplicate/sort, coerce numeric types, normalize timezones, and normalize corporate actions. 
- Introduce a small cache API (`CacheStore`, `CacheEntry`) and an `InMemoryCacheStore` implementation under `sentinel/market/cache/` and a central `EquitiesService` that orchestrates provider calls with pragmatic TTL cache keying and freshness policy. 
- Add chart-prep layer `CandleChartPayloadBuilder` to convert `BarSeries` + actions into renderer-friendly payloads. 
- Add a PySide6-facing `EquityChartViewModel` exposing signals (`loading_changed`, `payload_ready`, `error_changed`, `empty_changed`) and async request handling to keep UI responsive. 
- Wire up unit tests for query validation, normalization scaffolding, and chart payload behavior and add `yfinance` to project dependencies in `pyproject.toml`.

### Testing
- Ran unit tests: `python -m pytest tests/unit/test_equities_query.py tests/unit/test_equities_chart_payload.py` which passed (3 tests collected/passed). 
- Attempted full unit run including normalization: `python -m pytest tests/unit/test_equities_query.py tests/unit/test_equities_normalization.py tests/unit/test_equities_chart_payload.py` which failed during collection due to missing test environment dependency `pandas` (ModuleNotFoundError). 
- Note: tests exercise query validation, normalization logic (when `pandas` is available), and chart payload marker generation; CI should install `pandas` and `PySide6` (or use appropriate test stubs) to run the full suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd1fe9e1fc832cb52cd8a18ecb4404)